### PR TITLE
BRIGHTICS_HOME is set to the parent directory of bin directory, 

### DIFF
--- a/bin/setup.cmd
+++ b/bin/setup.cmd
@@ -4,7 +4,7 @@
 @ECHO OFF
 TITLE Setup BrighticsForWindows
 
-SET BRIGHTICS_HOME=%~dp0
+for %%B in (%~dp0\.) do SET BRIGHTICS_HOME=%%~dpB
 
 where /q python
 IF ERRORLEVEL 1 (


### PR DESCRIPTION
BRIGHTICS_HOME is set to the parent directory of bin directory, 
since setup.cmd finds requirements.txt for initial setup.