### PR TITLE
Fixed binarizer with much faster speed

### DIFF
--- a/function/python/brightics/function/extraction/extraction.py
+++ b/function/python/brightics/function/extraction/extraction.py
@@ -83,14 +83,12 @@ def _discretize_quantile(table, input_col, num_of_buckets=2, out_col_name='bucke
 def binarizer(table, column, threshold=0, threshold_type='greater', out_col_name=None):
     if out_col_name is None:
         out_col_name = 'binarized_' + str(column)
-    table[out_col_name] = 0
-    for t in range(0, len(table[column])):
-        if threshold_type == 'greater':
-            if table[column][t] > threshold:
-                table[out_col_name][t] = 1
-        else:
-            if table[column][t] >= threshold:
-                table[out_col_name][t] = 1
+        
+    if threshold_type == 'greater':
+        table[out_col_name] = table[column].apply(lambda x: 1 if x > threshold else 0)
+    else :
+        table[out_col_name] = table[column].apply(lambda x: 1 if x >= threshold else 0)
+
     return{'table':table}
 
 


### PR DESCRIPTION
Binarizer is a simple function, but it takes time more than expected.
took more than 90sec for data with 6000 rows, approximately somewhere between O(n^3) ~ O(n^2)
![bin](https://user-images.githubusercontent.com/7043208/50619525-fd155980-0f3c-11e9-9348-d3e0f8f4c29f.PNG)

In pandas dataframe, I think values should not be changed with direct index access, since dataframe  updates its index for each iteration. 

Now the complexity is O(n), and take less than a second.

This solves #152 .