### PR TITLE
usability of pivot and unpivot. unused groupby / Change text in group_by on Model 

### DIFF
--- a/function/python/brightics/common/groupby.py
+++ b/function/python/brightics/common/groupby.py
@@ -59,7 +59,7 @@ def _function_by_group(function, table=None, model=None, group_by=None, **params
     for repr_key in model_keys_containing_repr:
         rb = BrtcReprBuilder()
         for group in success_keys:
-            rb.addMD('{group}'.format(group=group))
+            rb.addMD('### - Group by {group_by} : [{group}]'.format(group_by=group_by, group=group))
             rb.merge(res_dict[repr_key]['_grouped_data']['data'][group]['_repr_brtc_'])
         res_dict[repr_key]['_repr_brtc_'] = rb.get()
 

--- a/function/python/brightics/function/transform/meta/pivot.json
+++ b/function/python/brightics/function/transform/meta/pivot.json
@@ -31,21 +31,8 @@
 		},
 		"params": [
 			{
-				"id": "values",
-				"label": "Values",
-				"description": "Column to aggregate",
-				"mandatory": true,
-				"items": [],
-				"visibleOption": [],
-				"control": "ColumnSelector",
-				"columnType": [],
-				"validation": [],
-				"multiple": true,
-				"rowCount": 5
-			},
-			{
 				"id": "index",
-				"label": "Index",
+				"label": "Rows",
 				"description": "column, Grouper",
 				"mandatory": false,
 				"items": [],
@@ -67,6 +54,19 @@
 				"columnType": [],
 				"validation": [],
 				"multiple": true
+			},
+			{
+				"id": "values",
+				"label": "Values",
+				"description": "Column to aggregate",
+				"mandatory": true,
+				"items": [],
+				"visibleOption": [],
+				"control": "ColumnSelector",
+				"columnType": [],
+				"validation": [],
+				"multiple": true,
+				"rowCount": 5
 			},
 			{
 				"id": "aggfunc",
@@ -129,18 +129,6 @@
 				"control": "CheckBox",
 				"columnType": [],
 				"validation": []
-			},
-			{
-				"id": "group_by",
-				"label": "Group By",
-				"description": "Columns to group by",
-				"mandatory": false,
-				"items": [],
-				"visibleOption": [],
-				"control": "ColumnSelector",
-				"columnType": [],
-				"validation": [],
-				"multiple": true
 			}
 		]
 	},

--- a/function/python/brightics/function/transform/meta/unpivot.json
+++ b/function/python/brightics/function/transform/meta/unpivot.json
@@ -29,8 +29,21 @@
         "params": [
             {
                 "id": "value_vars",
-                "label": "Measured Variables",
+                "label": "Values",
                 "description": "Measured variables",
+                "mandatory": true,
+                "items": [],
+                "visibleOption": [],
+                "control": "ColumnSelector",
+                "columnType": [],
+                "validation": [],
+                "multiple": true,
+                "rowCount": 5
+            },
+            {
+                "id": "id_vars",
+                "label": "Identifiers",
+                "description": "Identifier variables",
                 "mandatory": true,
                 "items": [],
                 "visibleOption": [],
@@ -65,18 +78,6 @@
                 "validation": [],
                 "type": "String",
                 "placeHolder": "value"
-            },
-            {
-                "id": "group_by",
-                "label": "Group By",
-                "description": "Columns to group by",
-                "mandatory": false,
-                "items": [],
-                "visibleOption": [],
-                "control": "ColumnSelector",
-                "columnType": [],
-                "validation": [],
-                "multiple": true
             }
         ]
     },

--- a/function/python/brightics/function/transform/reshaping.py
+++ b/function/python/brightics/function/transform/reshaping.py
@@ -1,34 +1,19 @@
 import pandas as pd
-import numpy as np
+
 from brightics.common.groupby import _function_by_group
 from brightics.common.validation import raise_runtime_error
 from brightics.common.utils import check_required_parameters
-import brightics.common.statistics as brtc_stat 
+import brightics.common.statistics as brtc_stat
 
 
-def unpivot(table, group_by=None, **params):
-    check_required_parameters(_unpivot, params, ['table'])
-    if group_by is not None:
-        return _function_by_group(_unpivot, table, group_by=group_by, **params)
-    else:
-        return _unpivot(table, **params)
-
-
-def _unpivot(table, value_vars, var_name=None, value_name='value', col_level=None):
-    id_vars = [column for column in table.columns if column not in value_vars]
+def unpivot(table, value_vars, var_name=None, value_name='value', col_level=None, id_vars=None):
+    #if delete this, it is not consistent with the previous version.
+    #id_vars = [column for column in table.columns if column not in value_vars] 
     out_table = pd.melt(table, id_vars=id_vars, value_vars=value_vars, var_name=var_name, value_name=value_name, col_level=col_level)
     return {'out_table': out_table}
 
 
-def pivot(table, group_by=None, **params):
-    check_required_parameters(_pivot, params, ['table'])
-    if group_by is not None:
-        return _function_by_group(_pivot, table, group_by=group_by, **params)
-    else:
-        return _pivot(table, **params)
-
-    
-def _pivot(table, values, aggfunc, index=None, columns=None):  # TODO
+def pivot(table, values, aggfunc, index=None, columns=None):  # TODO
 
     if index is None and columns is None:
         # TODO: assign an error code.


### PR DESCRIPTION
Change text in group_by on Model. #333

in pivot, values, columns but index. use indexes or indices. (consider also 'rows'.)
in unpivot, measured variables is unclear. how about to use values?

in both two functions, groupby is useless. please delete these.

in pivot, values and aggregate functions are far away from each other. how about to change the order.

For unpivot, now id_vars is selected all the columns except value_vars. Please make a column selector to choose id_vars. Please discuss usability of as-is and to-be. #329