### PR TITLE
Add data types for label column in Random Forest Classification Train

### DIFF
--- a/function/python/brightics/function/classification/meta/random_forest_classification_train.json
+++ b/function/python/brightics/function/classification/meta/random_forest_classification_train.json
@@ -55,9 +55,7 @@
                 "items": [],
                 "visibleOption": [],
                 "control": "ColumnSelector",
-                "columnType": [
-                    "String"
-                ],
+                "columnType": [],
                 "validation": [],
                 "multiple": false
             },


### PR DESCRIPTION
Random Forest Classification Train does not support numeric columns as
the label column.
We will let users select a label column of numeric data.
(issue #394)