### PR TITLE
Add the parameter class_weight in random forest classification train

### DIFF
--- a/function/python/brightics/function/classification/meta/random_forest_classification_train.json
+++ b/function/python/brightics/function/classification/meta/random_forest_classification_train.json
@@ -39,9 +39,7 @@
                     "Integer",
                     "Long",
                     "Float",
-                    "Double",
-                    "Decimal",
-                    "Boolean"
+                    "Double"
                 ],
                 "validation": [],
                 "type": "Double",
@@ -55,7 +53,13 @@
                 "items": [],
                 "visibleOption": [],
                 "control": "ColumnSelector",
-                "columnType": [],
+                "columnType": [
+                    "Integer",
+                    "Long",
+                    "Float",
+                    "Double",
+                    "String"
+                    ],
                 "validation": [],
                 "multiple": false
             },
@@ -76,7 +80,7 @@
             {
                 "id": "criterion",
                 "label": "Feature Selection Criterion",
-                "description": "The function to measure the quality of a split. Supported criteria are “gini” for the Gini impurity and “entropy” for the information gain. Note: this parameter is tree-specific.",
+                "description": "The function to measure the quality of a split. Supported criteria are �쐅ini�� for the Gini impurity and �쐃ntropy�� for the information gain. Note: this parameter is tree-specific.",
                 "mandatory": false,
                 "items": [
                     {
@@ -105,7 +109,7 @@
                 "control": "InputBox",
                 "columnType": [],
                 "validation": [],
-				"placeHolder": "value >= 1",
+                "placeHolder": "value >= 1",
                 "type": "Integer",
                 "min": 1
             },
@@ -121,7 +125,7 @@
                 "validation": [],
                 "placeHolder": "2 (value >= 2)",
                 "type": "Integer",
-				"min": 2
+                "min": 2
             },
             {
                 "id": "min_samples_leaf",
@@ -140,7 +144,7 @@
             {
                 "id": "max_features",
                 "label": "Number of Features",
-                "description": "The number of features to consider when looking for the best split:\n\nIf int, then consider max_features features at each split.\nIf float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.\nIf “auto”, then max_features=sqrt(n_features).\nIf “sqrt”, then max_features=sqrt(n_features) (same as “auto”).\nIf “log2”, then max_features=log2(n_features).\nIf None, then max_features=n_features.",
+                "description": "The number of features to consider when looking for the best split:\n\nIf int, then consider max_features features at each split.\nIf float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.\nIf �쏿uto��, then max_features=sqrt(n_features).\nIf �쐓qrt��, then max_features=sqrt(n_features) (same as �쏿uto��).\nIf �쐋og2��, then max_features=log2(n_features).\nIf None, then max_features=n_features.",
                 "mandatory": false,
                 "items": [
                     {
@@ -163,6 +167,19 @@
                 "control": "RadioButton",
                 "columnType": [],
                 "validation": []
+            },
+            {
+                "id": "class_weight",
+                "label": "Class Weight",
+                "description": "Weights associated with classes. If weights are not given, all classes are supposed to have weight one. Note that the class labels are considered in lexicographical order. ",
+                "mandatory": false,
+                "items": [],
+                "visibleOption": [],
+                "control": "ArrayInput",
+                "columnType": [],
+                "validation": [],
+                "placeHolder": "",
+                "type": "Integer"
             },
             {
                 "id": "random_state",

--- a/function/python/brightics/function/classification/meta/random_forest_classification_train.json
+++ b/function/python/brightics/function/classification/meta/random_forest_classification_train.json
@@ -59,7 +59,7 @@
                     "Float",
                     "Double",
                     "String"
-                    ],
+                ],
                 "validation": [],
                 "multiple": false
             },
@@ -80,7 +80,7 @@
             {
                 "id": "criterion",
                 "label": "Feature Selection Criterion",
-                "description": "The function to measure the quality of a split. Supported criteria are �쐅ini�� for the Gini impurity and �쐃ntropy�� for the information gain. Note: this parameter is tree-specific.",
+                "description": "The function to measure the quality of a split. ",
                 "mandatory": false,
                 "items": [
                     {
@@ -144,7 +144,7 @@
             {
                 "id": "max_features",
                 "label": "Number of Features",
-                "description": "The number of features to consider when looking for the best split:\n\nIf int, then consider max_features features at each split.\nIf float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.\nIf �쏿uto��, then max_features=sqrt(n_features).\nIf �쐓qrt��, then max_features=sqrt(n_features) (same as �쏿uto��).\nIf �쐋og2��, then max_features=log2(n_features).\nIf None, then max_features=n_features.",
+                "description": "The number of features to consider when looking for the best split.",
                 "mandatory": false,
                 "items": [
                     {

--- a/function/python/brightics/function/classification/meta/random_forest_classification_train.json
+++ b/function/python/brightics/function/classification/meta/random_forest_classification_train.json
@@ -159,7 +159,7 @@
                     },
                     {
                         "label": "n",
-                        "value": "None",
+                        "value": "n",
                         "default": false
                     }
                 ],
@@ -170,7 +170,7 @@
             },
             {
                 "id": "class_weight",
-                "label": "Class Weight",
+                "label": "Class Weights",
                 "description": "Weights associated with classes. If weights are not given, all classes are supposed to have weight one. Note that the class labels are considered in lexicographical order. ",
                 "mandatory": false,
                 "items": [],

--- a/function/python/brightics/function/classification/random_forest_classification.py
+++ b/function/python/brightics/function/classification/random_forest_classification.py
@@ -14,23 +14,21 @@
     limitations under the License.
 """
 
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import sklearn.utils
 from sklearn.ensemble import RandomForestClassifier 
 from brightics.common.repr import BrtcReprBuilder
 from brightics.common.repr import strip_margin
 from brightics.common.repr import plt2MD
 from brightics.common.repr import dict2MD
-from brightics.function.utils import _model_dict
 from brightics.common.groupby import _function_by_group
 from brightics.common.utils import check_required_parameters
 from brightics.common.utils import get_default_from_parameters_if_required
 from brightics.common.validation import validate
 from brightics.common.validation import greater_than_or_equal_to
 from brightics.common.validation import raise_error
-import sklearn.utils as sklearn_utils
-
-import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
 
 
 def random_forest_classification_train(table, group_by=None, **params):
@@ -72,17 +70,28 @@ def _plot_feature_importances(feature_cols, classifier):
 def _random_forest_classification_train(table, feature_cols, label_col,
                                  n_estimators=10, criterion="gini", max_depth=None, min_samples_split=2, min_samples_leaf=1,
                                  min_weight_fraction_leaf=0, max_features="sqrt",
-                                 max_leaf_nodes=None, min_impurity_decrease=0, random_state=None):   
+                                 max_leaf_nodes=None, min_impurity_decrease=0, class_weight=None, random_state=None):   
     
     X_train = table[feature_cols]
     y_train = table[label_col]   
 
-    if(sklearn_utils.multiclass.type_of_target(y_train) == 'continuous'):
+    if(sklearn.utils.multiclass.type_of_target(y_train) == 'continuous'):
         raise_error('0718', 'label_col')
     
     if max_features == "None":
         max_features = None
-            
+          
+    if class_weight is not None:
+        if y_train.dtype == str:
+            classes = sorted(list(set(y_train)), key=str.lower)
+        else:
+            classes = sorted(list(set(y_train)))
+
+        weights = class_weight
+        class_weight = {classes[0]: weights[0]}
+        for i in range(1, len(classes)):
+            class_weight[classes[i]] = weights[i]  
+    
     classifier = RandomForestClassifier(n_estimators=n_estimators,
                                         criterion=criterion,
                                         max_depth=max_depth,
@@ -92,6 +101,7 @@ def _random_forest_classification_train(table, feature_cols, label_col,
                                         max_features=max_features,
                                         max_leaf_nodes=max_leaf_nodes,
                                         min_impurity_decrease=min_impurity_decrease,
+                                        class_weight=class_weight,
                                         random_state=random_state)
     classifier.fit(X_train, y_train) 
 
@@ -106,6 +116,7 @@ def _random_forest_classification_train(table, feature_cols, label_col,
              'max_features': max_features,
              'max_leaf_nodes': max_leaf_nodes,
              'min_impurity_decrease': min_impurity_decrease,
+             'class_weight': class_weight,
              'random_state': random_state}
     
     model = dict()
@@ -118,10 +129,13 @@ def _random_forest_classification_train(table, feature_cols, label_col,
     rb.addMD(strip_margin("""
     | ## Random Forest Classification Train Result
     |
+    | ### Parameters
+    | {params}
+    |
     | ### Feature Importance
     | {fig_feature_importances}
     |
-    """.format(fig_feature_importances=fig_feature_importances))) 
+    """.format(params=dict2MD(params), fig_feature_importances=fig_feature_importances)))
         
     model['_repr_brtc_'] = rb.get()   
                

--- a/function/python/brightics/function/classification/random_forest_classification.py
+++ b/function/python/brightics/function/classification/random_forest_classification.py
@@ -78,19 +78,24 @@ def _random_forest_classification_train(table, feature_cols, label_col,
     if(sklearn.utils.multiclass.type_of_target(y_train) == 'continuous'):
         raise_error('0718', 'label_col')
     
-    if max_features == "None":
+    if max_features == "n":
         max_features = None
-          
-    if class_weight is not None:
-        if y_train.dtype == str:
-            classes = sorted(list(set(y_train)), key=str.lower)
+        
+    class_labels = list(set(y_train)) 
+    if class_weight is not None: 
+        if len(class_weight) != len(class_labels):
+            raise ValueError("Number of class weights should match number of labels.")
         else:
-            classes = sorted(list(set(y_train)))
+            if y_train.dtype == str:
+                classes = sorted((class_labels), key=str.lower)
+            else:
+                classes = sorted(class_labels)
 
-        weights = class_weight
-        class_weight = {classes[0]: weights[0]}
-        for i in range(1, len(classes)):
-            class_weight[classes[i]] = weights[i]  
+                weights = class_weight
+                class_weight = {classes[0]: weights[0]}
+                
+                for i in range(1, len(classes)):
+                    class_weight[classes[i]] = weights[i]  
     
     classifier = RandomForestClassifier(n_estimators=n_estimators,
                                         criterion=criterion,


### PR DESCRIPTION
#523
Non-uniform class weights were not available in random forest
classification train. We support the non-uniform class weights as an
input array and the order of class weights follows the lexicographical
order of class labels.

