### PR TITLE
Bug fix: K-means and K-means (Silhouette) does not support a single input column

### DIFF
--- a/function/python/brightics/function/transform/meta/_paraminfo_select_column.json
+++ b/function/python/brightics/function/transform/meta/_paraminfo_select_column.json
@@ -4,6 +4,7 @@
         "content": ""
     },
     "specJson": {
+    	"isFunction": false,
         "category": "transform",
         "func": "brightics.function.transform$select_column74584",
         "name": "brightics.function.transform$select_column",

--- a/function/python/brightics/function/transform/reshaping.py
+++ b/function/python/brightics/function/transform/reshaping.py
@@ -26,7 +26,8 @@ import brightics.common.statistics as brtc_stat
 
 def unpivot(table, value_vars, var_name=None, value_name='value', col_level=None, id_vars=None):
     # if delete this, it is not consistent with the previous version.
-    # id_vars = [column for column in table.columns if column not in value_vars] 
+    if id_vars is None:
+        id_vars = [column for column in table.columns if column not in value_vars] 
     out_table = pd.melt(table, id_vars=id_vars, value_vars=value_vars, var_name=var_name, value_name=value_name, col_level=col_level)
     return {'out_table': out_table}
 

--- a/va-server/visual-analytics/public/static/help/python/brightics.function.transform$join.md
+++ b/va-server/visual-analytics/public/static/help/python/brightics.function.transform$join.md
@@ -18,9 +18,9 @@ Merge DataFrame objects by performing a database-style join operation by columns
 2. **right_table**: table
 
 #### Parameters
-1. **Left Columns**<b style="color:red">*</b>: Columns to join on in the left(first) table.
-2. **Right Columns**<b style="color:red">*</b>: Columns to join on in the right(second) table.
-3. **Type**<b style="color:red">*</b>: How to handle the operation of the two objects.
+1. **Join Type**<b style="color:red">*</b>: How to handle the operation of the two objects.
+2. **Left Keys**<b style="color:red">*</b>: Columns to join on in the left(first) table.
+3. **Right Keys**<b style="color:red">*</b>: Columns to join on in the right(second) table.
 4. **Left Suffix**: Left Suffix.
    - Value type : String
 5. **Right Suffix**: Right Suffix.


### PR DESCRIPTION
A single input column had not been available due to PCA in K-means and K-means (Silhouette). 
We fix this problem and provide the 1-dimensional PCA graph on the line y=x.
We change the y-label of the Silhouette plot from index to cluster label.

Etc.
We apply a migration for Unpivot.
We change some labels in Join.