### PR TITLE
Update brightics_data_api.py

### DIFF
--- a/function/python/brightics/brightics_data_api.py
+++ b/function/python/brightics/brightics_data_api.py
@@ -217,7 +217,7 @@ def _generate_pil_data(p):
 def _generate_matplotlib_data(p):
     img = BytesIO()
     p.savefig(img, format='png')
-    p.clf()  # clear the current figure
+    p.close()  # clear the current figure
     return _png2uri(img.getvalue().strip())
 
 

--- a/function/python/brightics/function/recommendation/association_rule.py
+++ b/function/python/brightics/function/recommendation/association_rule.py
@@ -663,7 +663,6 @@ def _association_rule_visualization(table, option='multiple_to_single', edge_len
 
     model = _model_dict('Association rule')
     model['_repr_brtc_'] = rb.get()
-    plt.figure(figsize=(6.4,4.8))
     return{'model' : model}
     
     

--- a/function/python/brightics/function/textanalytics/word2vec.py
+++ b/function/python/brightics/function/textanalytics/word2vec.py
@@ -119,7 +119,6 @@ def _word2vec(table, input_col, size=100, window=5, min_count=1, seed=None, work
     out_table = pd.DataFrame()
     out_table['words'] = w2v.wv.index2word
     out_table['word_vectors'] = w2v.wv[vocab].tolist()
-    plt.figure(figsize=(6.4,4.8))
     return {'model': model, 'out_table': out_table}
 
 # def word2vec_update(table, model):


### PR DESCRIPTION
https://stackoverflow.com/questions/16661790/difference-between-plt-close-and-plt-clf

When we run a function with plotting a big figure, python process preserves the setting until it dies.
I think it is better to use plt.close() to prevent this bug.
Also, I think it is better for managing memories.