### PR TITLE
Restore multi chart

### DIFF
--- a/va-server/visual-analytics/public/css/va/brightics-va.css
+++ b/va-server/visual-analytics/public/css/va/brightics-va.css
@@ -1113,10 +1113,6 @@ input[type=search]::-webkit-search-cancel-button:hover {
 .brtc-va-editors-diagram-diagrameditorpage-function-multiselected-tools.brtc-va-editors-diagram-diagrameditorpage-function-multiselected-tools-bind-functions,
 .bos-widget-chart-item-wrapper[title="Decision Tree For Brightics"],
 .brtc-new-publish-url-wrapper.brtc-style-display-flex.brtc-style-flex-direction-row,
-.bcharts-ws-panel-toolitem[action="multichart"]
-{
-    display: none !important;
-}
 
 .brtc-va-editors-sheet-panels-basepanel[type=table] .brtc-va-editors-sheet-worksheet-selector {
     visibility: hidden;


### PR DESCRIPTION
I've removed `display: node` code on brightics-va.css file to restore multi-chart.

resolved #675 